### PR TITLE
Automatically close app on exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,6 +192,8 @@ if __name__ == "__main__":
             client.gui.status.update(_("gui", "status", "terminated"))
             # notify the user about the closure
             client.gui.grab_attention(sound=True)
+            # Close the application, so it can be automatically restarted
+            client.gui.close()
         await client.gui.wait_until_closed()
         # save the application state
         # NOTE: we have to do it after wait_until_closed,


### PR DESCRIPTION
I noticed that the app entered in a "Terminated" state after an exception occured instead of automatically restarting, like any other docker container where automatic restart is set up (and `jlesage/docker-baseimage-gui` was also supposed to take care of restarting the app in case of a crash because of this env var: https://github.com/fireph/docker-twitch-drops-miner/blob/a38a9d5141451d4162d894cbc8d94a114ab3bd4f/Dockerfile#L29 )

Hopefully with this change, an exception will successfully result in the app's termination, initiating an automatic restart.