### PR TITLE
Deployed update to allow optional advanced trigger for unlinked issues

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -394,10 +394,25 @@ class DropsCampaign:
         return len(self.timed_drops)
 
     @property
+    def priority_link_override(self) -> bool:
+        """
+        True when the user has enabled the advanced "priority link override"
+        setting and explicitly added this (unlinked) game to the Priority List.
+
+        This does not change Twitch's reported account-link state; Twitch may
+        still refuse to award drops for a campaign the account isn't linked to.
+        """
+        return (
+            self._twitch.settings.priority_link_override
+            and not self.linked
+            and self.game.name in self._twitch.settings.priority
+        )
+
+    @property
     def eligible(self) -> bool:
         if self.has_badge_or_emote:
             return self._twitch.settings.enable_badges_emotes
-        return self.linked
+        return self.linked or self.priority_link_override
 
     @cached_property
     def has_badge_or_emote(self) -> bool:

--- a/settings.py
+++ b/settings.py
@@ -22,6 +22,7 @@ class SettingsFile(TypedDict):
     tray_notifications: bool
     enable_badges_emotes: bool
     available_drops_check: bool
+    priority_link_override: bool
     priority_mode: PriorityMode
 
 
@@ -36,6 +37,7 @@ default_settings: SettingsFile = {
     "tray_notifications": True,
     "enable_badges_emotes": False,
     "available_drops_check": False,
+    "priority_link_override": False,
     "priority_mode": PriorityMode.PRIORITY_ONLY,
 }
 
@@ -61,6 +63,7 @@ class Settings:
     tray_notifications: bool
     enable_badges_emotes: bool
     available_drops_check: bool
+    priority_link_override: bool
     priority_mode: PriorityMode
 
     PASSTHROUGH = ("_settings", "_args", "_altered")

--- a/translate.py
+++ b/translate.py
@@ -172,6 +172,7 @@ class GUISettingsAdvanced(TypedDict):
     warning_text: str
     enable_badges_emotes: str
     available_drops_check: str
+    priority_link_override: str
 
 
 class GUIPriorityModes(TypedDict):
@@ -391,6 +392,9 @@ default_translation: Translation = {
                 ),
                 "enable_badges_emotes": "Enable partial support for badges and emotes: ",
                 "available_drops_check": "Enable extra available drops check: ",
+                "priority_link_override": (
+                    "Mine unlinked games from the Priority List: "
+                ),
             },
             "priority_modes": {
                 "priority_only": "Priority list only",

--- a/webui/components/settings/general_section.py
+++ b/webui/components/settings/general_section.py
@@ -123,6 +123,17 @@ class GeneralSection:
                         ),
                     ).bind_value_from(settings, "available_drops_check")
 
+                with ui.row().classes("items-center gap-2 text-xs"):
+                    ui.label(
+                        _("gui", "settings", "advanced", "priority_link_override")
+                    ).classes("flex-1")
+                    ui.switch(
+                        value=settings.priority_link_override,
+                        on_change=lambda e: GeneralSection._set_and_save(
+                            settings, "priority_link_override", e.value
+                        ),
+                    ).bind_value_from(settings, "priority_link_override")
+
             with ui.card().props("flat bordered").classes("w-full q-pa-sm"):
                 ui.label(_("gui", "settings", "reload_text")).classes("text-xs")
                 ui.button(


### PR DESCRIPTION
As discussed, I took a quick time to review what was required to add this into an optional flag.

Note to do it correctly it needed to be added into advanced and allow the translation flag to also be allowed.

This is quite a minor change but it resolves the issue discussed in https://github.com/fireph/docker-twitch-drops-miner/issues/54 